### PR TITLE
Include C++17 type_traits and C++20 chrono calendars

### DIFF
--- a/include/__config
+++ b/include/__config
@@ -810,6 +810,12 @@ typedef unsigned int   char32_t;
 #  define _LIBCPP_CONSTEXPR constexpr
 #endif
 
+#if _LIBCPP_STD_VER > 17
+#  define _LIBCPP_INLINE_CONSTEXPR inline constexpr
+#else
+#  define _LIBCPP_INLINE_CONSTEXPR static constexpr
+#endif
+
 #ifdef _LIBCPP_CXX03_LANG
 #  define _LIBCPP_DEFAULT {}
 #else

--- a/include/chrono
+++ b/include/chrono
@@ -2759,64 +2759,64 @@ inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(co
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
 
-template <class _Duration>
-class hh_mm_ss
-{
-private:
-    static_assert(__is_duration<_Duration>::value, "template parameter of hh_mm_ss must be a std::chrono::duration");
-    using __CommonType = common_type_t<_Duration, chrono::seconds>;
+// template <class _Duration>
+// class hh_mm_ss
+// {
+// private:
+//     static_assert(__is_duration<_Duration>::value, "template parameter of hh_mm_ss must be a std::chrono::duration");
+//     using __CommonType = common_type_t<_Duration, chrono::seconds>;
 
-    static constexpr uint64_t __pow10(unsigned __exp)
-    {
-        uint64_t __ret = 1;
-        for (unsigned __i = 0; __i < __exp; ++__i)
-            __ret *= 10U;
-        return __ret;
-    }
+//     static constexpr uint64_t __pow10(unsigned __exp)
+//     {
+//         uint64_t __ret = 1;
+//         for (unsigned __i = 0; __i < __exp; ++__i)
+//             __ret *= 10U;
+//         return __ret;
+//     }
 
-    static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
-    {
-        if (__n >= 2 && __d != 0 && __w < 19)
-            return 1 + __width(__n, __d % __n * 10, __w+1);
-        return 0;
-    }
+//     static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
+//     {
+//         if (__n >= 2 && __d != 0 && __w < 19)
+//             return 1 + __width(__n, __d % __n * 10, __w+1);
+//         return 0;
+//     }
 
-public:
-    static unsigned constexpr fractional_width = __width(__CommonType::period::den) < 19 ?
-                                                 __width(__CommonType::period::den) : 6u;
-    using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
+// public:
+//     static unsigned constexpr fractional_width = __width(__CommonType::period::den) < 19 ?
+//                                                  __width(__CommonType::period::den) : 6u;
+//     using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
 
-    constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
+//     constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
 
-    constexpr explicit hh_mm_ss(_Duration __d) noexcept :
-        __is_neg(__d < _Duration(0)),
-        __h(duration_cast<chrono::hours>  (abs(__d))),
-        __m(duration_cast<chrono::minutes>(abs(__d) - hours())),
-        __s(duration_cast<chrono::seconds>(abs(__d) - hours() - minutes())),
-        __f(duration_cast<precision>      (abs(__d) - hours() - minutes() - seconds()))
-        {}
+//     constexpr explicit hh_mm_ss(_Duration __d) noexcept :
+//         __is_neg(__d < _Duration(0)),
+//         __h(duration_cast<chrono::hours>  (abs(__d))),
+//         __m(duration_cast<chrono::minutes>(abs(__d) - hours())),
+//         __s(duration_cast<chrono::seconds>(abs(__d) - hours() - minutes())),
+//         __f(duration_cast<precision>      (abs(__d) - hours() - minutes() - seconds()))
+//         {}
 
-    constexpr bool is_negative()        const noexcept { return __is_neg; }
-    constexpr chrono::hours hours()     const noexcept { return __h; }
-    constexpr chrono::minutes minutes() const noexcept { return __m; }
-    constexpr chrono::seconds seconds() const noexcept { return __s; }
-    constexpr precision subseconds()    const noexcept { return __f; }
+//     constexpr bool is_negative()        const noexcept { return __is_neg; }
+//     constexpr chrono::hours hours()     const noexcept { return __h; }
+//     constexpr chrono::minutes minutes() const noexcept { return __m; }
+//     constexpr chrono::seconds seconds() const noexcept { return __s; }
+//     constexpr precision subseconds()    const noexcept { return __f; }
 
-    constexpr precision to_duration() const noexcept
-    {
-        auto __dur = __h + __m + __s + __f;
-        return __is_neg ? -__dur : __dur;
-    }
+//     constexpr precision to_duration() const noexcept
+//     {
+//         auto __dur = __h + __m + __s + __f;
+//         return __is_neg ? -__dur : __dur;
+//     }
 
-    constexpr explicit operator precision() const noexcept { return to_duration(); }
+//     constexpr explicit operator precision() const noexcept { return to_duration(); }
 
-private:
-    bool            __is_neg;
-    chrono::hours   __h;
-    chrono::minutes __m;
-    chrono::seconds __s;
-    precision       __f;
-};
+// private:
+//     bool            __is_neg;
+//     chrono::hours   __h;
+//     chrono::minutes __m;
+//     chrono::seconds __s;
+//     precision       __f;
+// };
 
 constexpr bool is_am(const hours& __h) noexcept { return __h >= hours( 0) && __h < hours(12); }
 constexpr bool is_pm(const hours& __h) noexcept { return __h >= hours(12) && __h < hours(24); }

--- a/include/chrono
+++ b/include/chrono
@@ -1577,34 +1577,41 @@ operator-(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, 
 class _LIBCPP_TYPE_VIS system_clock
 {
 public:
-    typedef microseconds                     duration;
+    typedef nanoseconds                      duration;
     typedef duration::rep                    rep;
     typedef duration::period                 period;
     typedef chrono::time_point<system_clock> time_point;
     static _LIBCPP_CONSTEXPR_AFTER_CXX11 const bool is_steady = false;
 
-    static time_point now() _NOEXCEPT;
-    static time_t     to_time_t  (const time_point& __t) _NOEXCEPT;
-    static time_point from_time_t(time_t __t) _NOEXCEPT;
-};
-
-#ifndef _LIBCPP_HAS_NO_MONOTONIC_CLOCK
-class _LIBCPP_TYPE_VIS steady_clock
-{
-public:
-    typedef nanoseconds                                   duration;
-    typedef duration::rep                                 rep;
-    typedef duration::period                              period;
-    typedef chrono::time_point<steady_clock, duration>    time_point;
-    static _LIBCPP_CONSTEXPR_AFTER_CXX11 const bool is_steady = true;
-
-    static time_point now() _NOEXCEPT;
-};
-
-typedef steady_clock high_resolution_clock;
+    inline _LIBCPP_INLINE_VISIBILITY
+    static time_point now() _NOEXCEPT
+    {
+#ifdef __CUDA_ARCH__
+        uint64_t time;
+        asm("mov.u64  %0, %globaltimer;":"=l"(time)::);
+        return time_point(nanoseconds(time));
 #else
-typedef system_clock high_resolution_clock;
+        return time_point(nanoseconds(
+                ::std::chrono::duration_cast<::std::chrono::nanoseconds>(
+                    ::std::chrono::system_clock::now().time_since_epoch()
+                ).count()
+               ));
 #endif
+    }
+    inline _LIBCPP_INLINE_VISIBILITY
+    static time_t to_time_t(const time_point& __t) _NOEXCEPT
+    {
+        return time_t(duration_cast<seconds>(__t.time_since_epoch()).count());
+    }
+    inline _LIBCPP_INLINE_VISIBILITY
+    static time_point from_time_t(time_t __t) _NOEXCEPT
+    {
+        return time_point(seconds(__t));;
+    }
+};
+
+using steady_clock = system_clock;
+using high_resolution_clock = steady_clock;
 
 #endif // _LIBCPP_HAS_CLOCK_API_EXTERNAL
 

--- a/include/chrono
+++ b/include/chrono
@@ -1981,27 +1981,27 @@ inline constexpr
 weekday_last    weekday::operator[](last_spec) const noexcept { return weekday_last{*this}; }
 
 
-inline constexpr last_spec last{};
-inline constexpr weekday   Sunday{0};
-inline constexpr weekday   Monday{1};
-inline constexpr weekday   Tuesday{2};
-inline constexpr weekday   Wednesday{3};
-inline constexpr weekday   Thursday{4};
-inline constexpr weekday   Friday{5};
-inline constexpr weekday   Saturday{6};
+_LIBCPP_INLINE_CONSTEXPR last_spec last{};
+_LIBCPP_INLINE_CONSTEXPR weekday   Sunday{0};
+_LIBCPP_INLINE_CONSTEXPR weekday   Monday{1};
+_LIBCPP_INLINE_CONSTEXPR weekday   Tuesday{2};
+_LIBCPP_INLINE_CONSTEXPR weekday   Wednesday{3};
+_LIBCPP_INLINE_CONSTEXPR weekday   Thursday{4};
+_LIBCPP_INLINE_CONSTEXPR weekday   Friday{5};
+_LIBCPP_INLINE_CONSTEXPR weekday   Saturday{6};
 
-inline constexpr month January{1};
-inline constexpr month February{2};
-inline constexpr month March{3};
-inline constexpr month April{4};
-inline constexpr month May{5};
-inline constexpr month June{6};
-inline constexpr month July{7};
-inline constexpr month August{8};
-inline constexpr month September{9};
-inline constexpr month October{10};
-inline constexpr month November{11};
-inline constexpr month December{12};
+_LIBCPP_INLINE_CONSTEXPR month January{1};
+_LIBCPP_INLINE_CONSTEXPR month February{2};
+_LIBCPP_INLINE_CONSTEXPR month March{3};
+_LIBCPP_INLINE_CONSTEXPR month April{4};
+_LIBCPP_INLINE_CONSTEXPR month May{5};
+_LIBCPP_INLINE_CONSTEXPR month June{6};
+_LIBCPP_INLINE_CONSTEXPR month July{7};
+_LIBCPP_INLINE_CONSTEXPR month August{8};
+_LIBCPP_INLINE_CONSTEXPR month September{9};
+_LIBCPP_INLINE_CONSTEXPR month October{10};
+_LIBCPP_INLINE_CONSTEXPR month November{11};
+_LIBCPP_INLINE_CONSTEXPR month December{12};
 
 
 class month_day {

--- a/include/chrono
+++ b/include/chrono
@@ -1572,7 +1572,7 @@ operator-(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, 
 /////////////////////// clocks ///////////////////////////
 //////////////////////////////////////////////////////////
 
-#ifndef _LIBCPP_HAS_CLOCK_API_EXTERNAL
+#ifdef _LIBCUDACXX_USE_CUDA_CLOCK
 
 class _LIBCPP_TYPE_VIS system_clock
 {
@@ -1613,11 +1613,47 @@ public:
 using steady_clock = system_clock;
 using high_resolution_clock = steady_clock;
 
-#endif // _LIBCPP_HAS_CLOCK_API_EXTERNAL
+#else
+#  ifndef _LIBCPP_HAS_CLOCK_API_EXTERNAL
+
+class _LIBCPP_TYPE_VIS system_clock
+{
+public:
+    typedef microseconds                     duration;
+    typedef duration::rep                    rep;
+    typedef duration::period                 period;
+    typedef chrono::time_point<system_clock> time_point;
+    static _LIBCPP_CONSTEXPR_AFTER_CXX11 const bool is_steady = false;
+
+    static time_point now() _NOEXCEPT;
+    static time_t     to_time_t  (const time_point& __t) _NOEXCEPT;
+    static time_point from_time_t(time_t __t) _NOEXCEPT;
+};
+
+#    ifndef _LIBCPP_HAS_NO_MONOTONIC_CLOCK
+class _LIBCPP_TYPE_VIS steady_clock
+{
+public:
+    typedef nanoseconds                                   duration;
+    typedef duration::rep                                 rep;
+    typedef duration::period                              period;
+    typedef chrono::time_point<steady_clock, duration>    time_point;
+    static _LIBCPP_CONSTEXPR_AFTER_CXX11 const bool is_steady = true;
+
+    static time_point now() _NOEXCEPT;
+};
+
+typedef steady_clock high_resolution_clock;
+#    else
+typedef system_clock high_resolution_clock;
+#    endif // _LIBCPP_HAS_NO_MONOTONIC_CLOCK
+
+#  endif // _LIBCPP_HAS_CLOCK_API_EXTERNAL
+#endif // _LIBCUDACXX_USE_CUDA_CLOCK
 
 #if _LIBCPP_STD_VER > 17
 
-#ifndef _LIBCPP_HAS_CLOCK_API_EXTERNAL
+#if !defined(_LIBCPP_HAS_CLOCK_API_EXTERNAL) || defined(_LIBCUDACXX_USE_CUDA_CLOCK)
 
 // [time.clock.file], type file_clock
 using file_clock = _VSTD_FS::_FilesystemClock;
@@ -2765,65 +2801,68 @@ inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(co
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(const years& __dy)  noexcept { *this = *this + __dy; return *this; }
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
 
-// template <class _Duration>
-// class hh_mm_ss
-// {
-// private:
-//     static_assert(__is_duration<_Duration>::value, "template parameter of hh_mm_ss must be a std::chrono::duration");
-//     using __CommonType = common_type_t<_Duration, chrono::seconds>;
+template <class _Duration>
+class hh_mm_ss
+{
+private:
+    static_assert(__is_duration<_Duration>::value, "template parameter of hh_mm_ss must be a std::chrono::duration");
+    using __CommonType = common_type_t<_Duration, chrono::seconds>;
 
-//     static constexpr uint64_t __pow10(unsigned __exp)
-//     {
-//         uint64_t __ret = 1;
-//         for (unsigned __i = 0; __i < __exp; ++__i)
-//             __ret *= 10U;
-//         return __ret;
-//     }
+    static constexpr uint64_t __pow10(unsigned __exp)
+    {
+        uint64_t __ret = 1;
+        for (unsigned __i = 0; __i < __exp; ++__i)
+            __ret *= 10U;
+        return __ret;
+    }
 
-//     static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
-//     {
-//         if (__n >= 2 && __d != 0 && __w < 19)
-//             return 1 + __width(__n, __d % __n * 10, __w+1);
-//         return 0;
-//     }
+    static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
+    {
+        if (__n >= 2 && __d != 0 && __w < 19)
+            return 1 + __width(__n, __d % __n * 10, __w+1);
+        return 0;
+    }
 
-// public:
-//     static unsigned constexpr fractional_width = __width(__CommonType::period::den) < 19 ?
-//                                                  __width(__CommonType::period::den) : 6u;
-//     using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
+public:
+    static unsigned constexpr fractional_width = __width(__CommonType::period::den) < 19 ?
+                                                 __width(__CommonType::period::den) : 6u;
+    using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
 
-//     constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
+    constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
 
-//     constexpr explicit hh_mm_ss(_Duration __d) noexcept :
-//         __is_neg(__d < _Duration(0)),
-//         __h(duration_cast<chrono::hours>  (abs(__d))),
-//         __m(duration_cast<chrono::minutes>(abs(__d) - hours())),
-//         __s(duration_cast<chrono::seconds>(abs(__d) - hours() - minutes())),
-//         __f(duration_cast<precision>      (abs(__d) - hours() - minutes() - seconds()))
-//         {}
+    constexpr explicit hh_mm_ss(_Duration __d) noexcept :
+        __is_neg(__d < _Duration(0)),
+        __h(duration_cast<chrono::hours>  (abs(__d))),
+        __m(duration_cast<chrono::minutes>(abs(__d) - hours())),
+        __s(duration_cast<chrono::seconds>(abs(__d) - hours() - minutes())),
+        __f(duration_cast<precision>      (abs(__d) - hours() - minutes() - seconds()))
+        {}
 
-//     constexpr bool is_negative()        const noexcept { return __is_neg; }
-//     constexpr chrono::hours hours()     const noexcept { return __h; }
-//     constexpr chrono::minutes minutes() const noexcept { return __m; }
-//     constexpr chrono::seconds seconds() const noexcept { return __s; }
-//     constexpr precision subseconds()    const noexcept { return __f; }
+    constexpr bool is_negative()        const noexcept { return __is_neg; }
+    constexpr chrono::hours hours()     const noexcept { return __h; }
+    constexpr chrono::minutes minutes() const noexcept { return __m; }
+    constexpr chrono::seconds seconds() const noexcept { return __s; }
+    constexpr precision subseconds()    const noexcept { return __f; }
 
-//     constexpr precision to_duration() const noexcept
-//     {
-//         auto __dur = __h + __m + __s + __f;
-//         return __is_neg ? -__dur : __dur;
-//     }
+    constexpr precision to_duration() const noexcept
+    {
+        auto __dur = __h + __m + __s + __f;
+        return __is_neg ? -__dur : __dur;
+    }
 
-//     constexpr explicit operator precision() const noexcept { return to_duration(); }
+    constexpr explicit operator precision() const noexcept { return to_duration(); }
 
-// private:
-//     bool            __is_neg;
-//     chrono::hours   __h;
-//     chrono::minutes __m;
-//     chrono::seconds __s;
-//     precision       __f;
-// };
+private:
+    bool            __is_neg;
+    chrono::hours   __h;
+    chrono::minutes __m;
+    chrono::seconds __s;
+    precision       __f;
+};
+
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
 
 constexpr bool is_am(const hours& __h) noexcept { return __h >= hours( 0) && __h < hours(12); }
 constexpr bool is_pm(const hours& __h) noexcept { return __h >= hours(12) && __h < hours(24); }

--- a/include/ratio
+++ b/include/ratio
@@ -294,10 +294,14 @@ typedef ratio<1000000000000000000LL, 1LL> exa;
 template <class _R1, class _R2>
 struct __ratio_multiply
 {
-// private:
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
+private:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     static const intmax_t __gcd_n1_d2 = __static_gcd<_R1::num, _R2::den>::value;
     static const intmax_t __gcd_d1_n2 = __static_gcd<_R1::den, _R2::num>::value;
-// public:
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
+public:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     typedef typename ratio
         <
             __ll_mul<_R1::num / __gcd_n1_d2, _R2::num / __gcd_d1_n2>::value,
@@ -321,10 +325,14 @@ struct _LIBCPP_TEMPLATE_VIS ratio_multiply
 template <class _R1, class _R2>
 struct __ratio_divide
 {
-// private:
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
+private:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
     static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
-// public:
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
+public:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     typedef typename ratio
         <
             __ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
@@ -348,10 +356,14 @@ struct _LIBCPP_TEMPLATE_VIS ratio_divide
 template <class _R1, class _R2>
 struct __ratio_add
 {
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
 private:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
     static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
 public:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     typedef typename ratio_multiply
         <
             ratio<__gcd_n1_n2, _R1::den / __gcd_d1_d2>,
@@ -383,10 +395,14 @@ struct _LIBCPP_TEMPLATE_VIS ratio_add
 template <class _R1, class _R2>
 struct __ratio_subtract
 {
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
 private:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
     static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
+#ifndef _LIBCUDACXX_USE_CXX20_CHRONO
 public:
+#endif // _LIBCUDACXX_USE_CXX20_CHRONO
     typedef typename ratio_multiply
         <
             ratio<__gcd_n1_n2, _R1::den / __gcd_d1_d2>,

--- a/include/ratio
+++ b/include/ratio
@@ -294,10 +294,10 @@ typedef ratio<1000000000000000000LL, 1LL> exa;
 template <class _R1, class _R2>
 struct __ratio_multiply
 {
-private:
+// private:
     static const intmax_t __gcd_n1_d2 = __static_gcd<_R1::num, _R2::den>::value;
     static const intmax_t __gcd_d1_n2 = __static_gcd<_R1::den, _R2::num>::value;
-public:
+// public:
     typedef typename ratio
         <
             __ll_mul<_R1::num / __gcd_n1_d2, _R2::num / __gcd_d1_n2>::value,
@@ -321,10 +321,10 @@ struct _LIBCPP_TEMPLATE_VIS ratio_multiply
 template <class _R1, class _R2>
 struct __ratio_divide
 {
-private:
+// private:
     static const intmax_t __gcd_n1_n2 = __static_gcd<_R1::num, _R2::num>::value;
     static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
-public:
+// public:
     typedef typename ratio
         <
             __ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,


### PR DESCRIPTION
This PR and its [sister PR in `ogiroux/freestanding`](https://github.com/ogiroux/freestanding/pull/8) encapsulate the changes necessary to use the C++17 type_traits and C++20 chrono calendars in cudf with the -std=c++14 flag. See the notes in that PR for a description of these commits.